### PR TITLE
fix(email): self-healing mail template load (root cause: signup 100% failing on dev)

### DIFF
--- a/src/app/adapter.py
+++ b/src/app/adapter.py
@@ -71,8 +71,21 @@ async def db_auto_session():
 # client/repo/adapter
 ########################
 async def init_mail_template_cache() -> MailTemplateCache:
-    async for session in db_session():
-        return MailTemplateCache(db_session=session)
+    # Open the session via async-with directly (not via the db_session()
+    # generator) so it is properly closed when this function returns. The
+    # earlier `async for session in db_session(): return ...` pattern
+    # abandoned the generator without an explicit aclose(), leaking a
+    # connection that surfaced later as the SAWarning about non-checked-in
+    # connections being terminated by GC.
+    #
+    # Prime the in-memory template *inside* the session scope so that, by
+    # the time we return, the cache is fully populated and never needs to
+    # touch the (about-to-be-closed) session again.
+    session_local = await sql_rsc.access()
+    async with session_local() as session:
+        cache = MailTemplateCache(db_session=session)
+        await cache.get_mail_template()
+        return cache
 
 
 email_client = EmailClient(ses=email_rec, mail_template_cache_factory=init_mail_template_cache)

--- a/src/infra/client/email.py
+++ b/src/infra/client/email.py
@@ -1,5 +1,6 @@
 import os
 import json
+import asyncio
 import aioboto3
 from pydantic import EmailStr
 from botocore.exceptions import ClientError
@@ -27,12 +28,31 @@ class EmailClient:
         self.ses = ses
         self._mail_template_cache_factory = mail_template_cache_factory
         self.template_cache: MailTemplateCache | None = None
+        # Single-flight lock: under cold-start, requests can pile up before
+        # the template is loaded; we want exactly one factory call, not N.
+        self._init_lock = asyncio.Lock()
 
     async def init(self):
-        self.template_cache = await self._mail_template_cache_factory()
+        # Idempotent and optional. load_template() self-heals on every call,
+        # so a request that lands before warmup finishes still works.
+        await self._ensure_loaded()
+
+    async def _ensure_loaded(self) -> None:
+        # Fast path: cache already populated.
+        if self.template_cache is not None and self.template_cache._cached_mail_template:
+            return
+        async with self._init_lock:
+            # Re-check inside the lock — another caller may have loaded it
+            # while we were waiting.
+            if self.template_cache is not None and self.template_cache._cached_mail_template:
+                return
+            # Build a fresh cache (factory primes it inside its own session
+            # scope, so what we get back is already usable). Only publish
+            # after success — render_email() never sees a half-init cache.
+            self.template_cache = await self._mail_template_cache_factory()
 
     async def load_template(self):
-        await self.template_cache.get_mail_template()
+        await self._ensure_loaded()
 
     async def send_content(self, recipient: EmailStr, subject: str, body: str) -> None:
         log.info(f'send email: {recipient}, subject: {subject}, body: {body}')


### PR DESCRIPTION
﻿## Summary

- Fix every signup on dev failing with `email_send_registration_link_error`.
- Self-heal the mail-template load so requests don't depend on background warmup finishing first.
- Stop leaking a postgres connection per cold start.

## Root cause

CloudWatch on `x-career-auth-dev-app` showed two distinct error messages on the same endpoint, mixed roughly 3:1:

\\\
Error sending email: Template not loaded. Call get_mail_template() first.
\\\

\\\
SAWarning: The garbage collector is trying to clean up non-checked-in connection
           ... which will be terminated.
\\\

Both originate from the same wiring:

1. **Race against fire-and-forget warmup.** `main.py` runs `email_client.init()` via `asyncio.create_task(_warmup_resources())` (introduced in e5e1e1b to unblock cold starts). Requests landing before warmup finished saw `EmailClient.template_cache is None`; `send_signup_confirm_email` then called `render_email` on the half-initialised cache and raised `Template not loaded`.
2. **Leaked DB session in the factory.** `init_mail_template_cache` consumed the `db_session()` async generator with `async for ... return ...`, which abandoned the generator without an explicit `aclose()`. The `async with` inside `db_session()` never ran on exit, so the asyncpg connection was leaked until GC -- the SAWarning.

The original (pre-e5e1e1b) `await email_client.init()` in startup masked #1 by serialising warmup against the first request. e5e1e1b removed that backstop; #1 became visible immediately.

## Fix

This is the option-C variant from triage: make the load self-healing rather than hardening the warmup ordering. Two surgical edits, no new files.

- **`adapter.init_mail_template_cache`** -- open the session via `async with session_local()` directly (not via the `db_session()` generator) so it closes deterministically on return; prime `cache.get_mail_template()` *inside* the session scope so the cache is fully populated by the time it leaves the function. Eliminates the SAWarning.
- **`EmailClient`** -- replace `init/load_template` with a self-healing `_ensure_loaded` guarded by an `asyncio.Lock`. Fast-path returns immediately when the cache is populated; otherwise exactly one caller invokes the factory while concurrent callers wait. Warmup `init()` is now idempotent and optional: a request that lands before warmup (or after a failed warmup) recovers on first use.

Per-call `send_signup_confirm_email` / `send_conform_code` / `send_reset_password_comfirm_email` keep their existing `await self.load_template()` then `self.template_cache.render_email(...)` shape -- no signature changes.

## Out of scope (follow-up)

Real signups will still fail for unverified recipients while AWS SES is in **sandbox mode** (`ProductionAccessEnabled: false`; only 9 identities verified). That requires a manual production-access request in the AWS Console -- unrelated to this code path. With this PR, signups against verified test addresses (e.g. `testing_visitor@xchange.com.tw`) will work reliably; without this PR, even those failed ~75% of the time due to the race.

## Test plan

- [ ] Merge to `dev`, let CI redeploy
- [ ] Force a cold start (e.g. update an env var to no-op value)
- [ ] Hit `POST /dev/api/v1/auth/signup` with `testing_visitor@xchange.com.tw` repeatedly -- expect 201 every time, no `Template not loaded` in CloudWatch
- [ ] Confirm `SAWarning: ... non-checked-in connection` no longer appears in Auth logs after a fresh start
