### PR TITLE
chore(gitignore): 忽略 venv313（Python 3.13 升級用的獨立 venv）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ var/
 .idea
 node_modules
 venv
+venv313/
 .venv
 **/**__pycache__
 **.db


### PR DESCRIPTION
階段 2：3.13 venv 與 3.9 venv 並存以便升級期間 A/B 比對行為，
venv313 不入版控。原生依賴（asyncpg 0.30 / greenlet 3.1.1 /
pydantic-core）已確認能在 3.13 安裝並 import。