### PR TITLE
Refactor Pydantic models and services to v2 native API

### DIFF
--- a/src/domain/auth/model/auth_entity.py
+++ b/src/domain/auth/model/auth_entity.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, ConfigDict
 from src.config.constant import AccountType
 from src.infra.util.time_util import current_seconds
 from src.infra.db.sql.orm.auth_orm import Account
@@ -19,8 +19,7 @@ class AccountEntity(BaseModel):
     created_at: Optional[int] = 0
     updated_at: Optional[int] = 0
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
     def register_format(self):

--- a/src/domain/auth/model/auth_model.py
+++ b/src/domain/auth/model/auth_model.py
@@ -1,6 +1,6 @@
 import json
 from typing import Any, Dict, List, Optional, Union
-from pydantic import BaseModel, EmailStr, validator, Field
+from pydantic import BaseModel, EmailStr, Field, ConfigDict
 from ....domain.auth.model.auth_entity import AccountEntity
 from ....infra.util.auth_util import *
 from ....config.constant import AccountType
@@ -83,8 +83,7 @@ class AccountVO(BaseModel):
     region: str
     user_id: int
 
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 class DeleteAccountDTO(BaseModel):
@@ -99,5 +98,4 @@ class AccountOauthVO(AccountVO):
     region: str
     user_id: int
 
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)

--- a/src/domain/auth/model/gateway_auth_model.py
+++ b/src/domain/auth/model/gateway_auth_model.py
@@ -1,6 +1,6 @@
 import json
 from typing import Any, Dict, List, Optional, Union
-from pydantic import BaseModel, EmailStr, validator
+from pydantic import BaseModel, EmailStr, field_validator, ConfigDict
 from ....config.exception import ClientException
 import logging
 
@@ -12,35 +12,38 @@ class SignupDTO(BaseModel):
     password: str
     confirm_password: str
 
-    @validator('confirm_password')
-    def passwords_match(cls, v, values, **kwargs):
-        if 'password' in values and v != values['password']:
+    @field_validator('confirm_password')
+    @classmethod
+    def passwords_match(cls, v, info):
+        if 'password' in info.data and v != info.data['password']:
             raise ClientException(msg='passwords do not match')
         return v
 
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             'example': {
                 'email': 'user@example.com',
                 'password': 'secret',
                 'confirm_password': 'secret',
-            },
+            }
         }
+    )
 
 
 class SignupConfirmDTO(BaseModel):
-    region: Optional[str]
+    region: Optional[str] = None
     email: EmailStr
     code: str
 
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             'example': {
                 'region': 'us-west-2',
                 'email': 'user@example.com',
                 'code': '106E7B',
-            },
+            }
         }
+    )
 
 
 class LoginOauthDTO(BaseModel):
@@ -48,36 +51,37 @@ class LoginOauthDTO(BaseModel):
     oauth_id: str
     # access_token: str
 
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             'example': {
                 'email': 'user@example.com',
                 'oauth_id': 'oauth_id',
                 # 'access_token': 'access_token'
-            },
+            }
         }
-
+    )
 
 class LoginDTO(BaseModel):
     email: EmailStr
     password: str
 
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             'example': {
                 'email': 'user@example.com',
                 'password': 'secret',
-            },
+            }
         }
+    )
 
 
 class SSOLoginDTO(BaseModel):
     code: str
     state: str
-    sso_type: Optional[str]
+    sso_type: Optional[str] = None
 
     def to_dict(self):
-        d = super().dict()
+        d = super().model_dump()
         d.pop('sso_type', None)
         return d
 
@@ -87,35 +91,36 @@ class ResetPasswordDTO(BaseModel):
     password: str
     confirm_password: str
 
-    @validator('confirm_password')
-    def passwords_match(cls, v, values, **kwargs):
-        if 'password' in values and v != values['password']:
+    @field_validator('confirm_password')
+    @classmethod
+    def passwords_match(cls, v, info):
+        if 'password' in info.data and v != info.data['password']:
             raise ClientException(msg='passwords do not match')
         return v
-
-    class Config:
-        schema_extra = {
+    
+    model_config = ConfigDict(
+        json_schema_extra={
             'example': {
                 'register_email': 'user@example.com',
                 'password': 'secret',
                 'confirm_password': 'secret',
-            },
+            }
         }
-
+    )
 
 class UpdatePasswordDTO(ResetPasswordDTO):
-    origin_password: Optional[str]
+    origin_password: Optional[str] = None
 
-    class Config:
-        schema_extra = {
+    model_config=ConfigDict(
+        json_schema_extra={
             'example': {
                 'register_email': 'user@example.com',
                 'password': 'secret2',
                 'confirm_password': 'secret2',
                 'origin_password': 'secret',
-            },
+            }
         }
-
+    )
 
 class BaseAuthDTO(BaseModel):
     # registration region

--- a/src/domain/auth/service/auth_service.py
+++ b/src/domain/auth/service/auth_service.py
@@ -203,7 +203,7 @@ class AuthService:
 
         except Exception as e:
             log.error(
-                f"{self.cls_name}.signup [unknown_err] data:%s, account_entity:%s, err:%s",
+                f"{self.cls_name}.login [unknown_err] data:%s, account_entity:%s, err:%s",
                 data,
                 None if account_entity is None else account_entity.model_dump(),
                 e.__str__(),

--- a/src/domain/auth/service/auth_service.py
+++ b/src/domain/auth/service/auth_service.py
@@ -154,13 +154,13 @@ class AuthService:
             if account_entity is None:
                 raise ServerException(msg="Email already registered")
 
-            return auth.AccountVO.parse_obj(account_entity.dict())
+            return auth.AccountVO.model_validate(account_entity.model_dump())
 
         except Exception as e:
             log.error(
                 f"{self.cls_name}.signup [unknown_err] data:%s, account_entity:%s, err:%s",
                 data,
-                None if account_entity is None else account_entity.dict(),
+                None if account_entity is None else account_entity.model_dump(),
                 e.__str__(),
             )
             err_msg = getattr(e, "msg", "Unable to signup")
@@ -199,13 +199,13 @@ class AuthService:
             ):
                 raise UnauthorizedException(msg="Error password")
 
-            return auth.AccountVO.parse_obj(account_entity.dict())
+            return auth.AccountVO.model_validate(account_entity.model_dump())
 
         except Exception as e:
             log.error(
                 f"{self.cls_name}.signup [unknown_err] data:%s, account_entity:%s, err:%s",
                 data,
-                None if account_entity is None else account_entity.dict(),
+                None if account_entity is None else account_entity.model_dump(),
                 e.__str__(),
             )
             err_msg = getattr(e, "msg", "Unable to login")
@@ -252,7 +252,7 @@ class AuthService:
             log.error(
                 f"{self.cls_name}.update_password [unknown_err] data: %s, account_entity: %s, err: %s",
                 data,
-                None if account_entity is None else account_entity.dict(),
+                None if account_entity is None else account_entity.model_dump(),
                 e.__str__(),
             )
             err_msg = getattr(e, "msg", "Unable to update password")

--- a/src/domain/auth/service/oauth_service.py
+++ b/src/domain/auth/service/oauth_service.py
@@ -62,13 +62,13 @@ class OauthService(AuthService):
             if account_entity is None:
                 raise ServerException(msg="Google email already registered")
 
-            return auth.AccountOauthVO.parse_obj(account_entity.dict())
+            return auth.AccountOauthVO.model_validate(account_entity.model_dump())
 
         except Exception as e:
             log.error(
                 f"{self.cls_name}.signup [unknown_err] data:%s, account_entity:%s, err:%s",
                 data,
-                None if account_entity is None else account_entity.dict(),
+                None if account_entity is None else account_entity.model_dump(),
                 e.__str__(),
             )
             err_msg = getattr(e, "msg", "Unable to signup")
@@ -100,7 +100,7 @@ class OauthService(AuthService):
 
             # 2. 驗證登入資訊
             if data.oauth_id == account_entity.oauth_id:
-                return auth.AccountOauthVO.parse_obj(account_entity.dict())
+                return auth.AccountOauthVO.model_validate(account_entity.model_dump())
             else:
                 raise ServerException(msg="Your google account is not valid")
 
@@ -108,7 +108,7 @@ class OauthService(AuthService):
             log.error(
                 f"{self.cls_name}.signup [unknown_err] data:%s, account_entity:%s, err:%s",
                 data,
-                None if account_entity is None else account_entity.dict(),
+                None if account_entity is None else account_entity.model_dump(),
                 e.__str__(),
             )
             err_msg = getattr(e, "msg", "Unable to login")

--- a/src/infra/db/sql/orm/auth_orm.py
+++ b/src/infra/db/sql/orm/auth_orm.py
@@ -5,7 +5,7 @@ from sqlalchemy import (
     String,
     Boolean,
 )
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 

--- a/src/infra/db/sql/orm/mail_template_orm.py
+++ b/src/infra/db/sql/orm/mail_template_orm.py
@@ -4,7 +4,7 @@ from sqlalchemy import (
     DateTime,
     String,
 )
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 

--- a/src/router/v1/auth.py
+++ b/src/router/v1/auth.py
@@ -59,7 +59,7 @@ async def signup(
     res = await _auth_service.signup(
         db, payload
     )
-    return post_success(data=res.dict())
+    return post_success(data=res.model_dump())
 
 
 @router.post('/login',
@@ -70,7 +70,7 @@ async def login(
     db: AsyncSession = Depends(db_session),
 ):
     res = await _auth_service.login(db, payload)
-    return post_success(data=res.dict())
+    return post_success(data=res.model_dump())
 
 
 @router.put('/password/update')

--- a/src/router/v1/oauth.py
+++ b/src/router/v1/oauth.py
@@ -43,7 +43,7 @@ async def signup_oauth(
         )
     else:
         raise ServerException('Invalid oauth type')
-    return post_success(data=res.dict())
+    return post_success(data=res.model_dump())
 
 
 @router.post('/login/oauth/{auth_type}',
@@ -58,4 +58,4 @@ async def login_oauth(
         res = await _oauth_service.login_oauth_google(db, payload)
     else:
         raise ServerException('Invalid oauth type')
-    return post_success(data=res.dict())
+    return post_success(data=res.model_dump())


### PR DESCRIPTION
- Pydantic v1 升級到 Pydantic v2, 原先的 schema 採用 Class Config -> 改成 ConfigDict
- declarative_base 改成從 sqlalchemy.orm import, 原先是 sqlalchemy.ext.declarative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication and OAuth data handling for improved compatibility with modern validation and serialization standards.
  * Improved password validation and handling of optional authentication fields.
  * Updated database model configuration to use current ORM conventions.
  * Preserved existing authentication flows, response formats, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->